### PR TITLE
Improve default swarm spit

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_spitball/init.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_spitball/init.lua
@@ -35,7 +35,7 @@ function ENT:Explode()
 		local dmginfo = DamageInfo()
 		dmginfo:SetAttacker( self:GetOwner() )
 		dmginfo:SetInflictor( self )
-		dmginfo:SetDamage( 8 )
+		dmginfo:SetDamage( 7 )
 		v:TakeDamageInfo( dmginfo )
 	end
 end

--- a/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_spitball/init.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_spitball/init.lua
@@ -13,12 +13,9 @@ function ENT:Initialize()
 
 	self:SetCollisionGroup( COLLISION_GROUP_PROJECTILE )
 	
-	
 	if SERVER then
 		util.SpriteTrail(self.Entity, 0, Color(25, 155, 0, 255), false, 25, 1, 0.3, 45, "trails/plasma.vmt")
-    end
-
-	if SERVER then
+    
 		local phys = self:GetPhysicsObject()
 		if phys:IsValid() then
 			phys:Wake()
@@ -28,15 +25,7 @@ function ENT:Initialize()
 	self.Created = CurTime()
 end
 
-
-function ENT:Think()
-
-end
-
-
 function ENT:Explode()
-
-
 	-- SFX
 	ParticleEffect( "spit_blast", self:GetPos(), Angle(0, 0, 0), nil )
 	self.Entity:EmitSound( "alien/acid_hit.wav", 100, math.random(95,125) );
@@ -46,21 +35,12 @@ function ENT:Explode()
 		local dmginfo = DamageInfo()
 		dmginfo:SetAttacker( self:GetOwner() )
 		dmginfo:SetInflictor( self )
-		dmginfo:SetDamage( 6 )
+		dmginfo:SetDamage( 8 )
 		v:TakeDamageInfo( dmginfo )
 	end
-
 end
-
 
 function ENT:PhysicsCollide( data, phys )
-
 	self:Explode()
 	self:Remove()
-
-end
-
-
-function ENT:OnRemove()
-
 end


### PR DESCRIPTION
Increase damage from 6 to 8. Exactly a 10 hit kill as damage isn't to scale. Extensive testing has demonstrated that six is far too weak to be balanced.

Fix and cleanup the file's formatting. Remove unused functions plus merge if server redundancy.