### PR TITLE
Remove Ignite and Cleanup

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_spitball_fire/init.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_spitball_fire/init.lua
@@ -13,12 +13,9 @@ function ENT:Initialize()
 
 	self:SetCollisionGroup( COLLISION_GROUP_PROJECTILE )
 	
-	
 	if SERVER then
 		util.SpriteTrail(self.Entity, 0, Color(255, 85, 0, 255), false, 25, 1, 0.3, 45, "trails/plasma.vmt")
-    end
 
-	if SERVER then
 		local phys = self:GetPhysicsObject()
 		if phys:IsValid() then
 			phys:Wake()
@@ -44,34 +41,22 @@ end
 
 
 function ENT:Explode()
-
 	-- SFX
 	ParticleEffect( "spit_blast_fire", self:GetPos(), Angle(0, 0, 0), nil )
 	self.Entity:EmitSound( "weapons/demon/hit2.wav", 100, math.random(85,95) );
 
 	-- Damage in sphere
-	for _, v in ipairs(ents.FindInSphere( self:GetPos(), 105 )) do
+	for _, v in ipairs(ents.FindInSphere( self:GetPos(), 135 )) do
 		local dmginfo = DamageInfo()
 		dmginfo:SetAttacker( self:GetOwner() )
 		dmginfo:SetInflictor( self )
-		dmginfo:SetDamage( 5 )
+		dmginfo:SetDamage( 8 )
 		v:TakeDamageInfo( dmginfo )
-		if v:IsPlayer() and !v:IsAlien() then
-			v:Ignite(0.8)
-		end
 	end
-
 end
 
 
 function ENT:PhysicsCollide( data, phys )
-
 	self:Explode()
 	self:Remove()
-
-end
-
-
-function ENT:OnRemove()
-
 end


### PR DESCRIPTION
By popular feedback from regular Morbus players, ignite is a really annoying screen blocker they dreadfully hate. This makes the chemical bomb ability to strong because they can't see anything when shooting at broods. Removing it and simply increasing the range + damage over default is the way to go. These are the stats I've been running a full server for awhile.
- 8 damage / 10 hits to kill and a range increase from 105 to 135.