### PR TITLE
Patch Swarm Spit Exploit

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_swarm/shared.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_swarm/shared.lua
@@ -89,7 +89,10 @@ end
 
 function SWEP:PrimaryAttack()
     self.Weapon:SetNextPrimaryFire( CurTime() + self.Delay )
-    self.Weapon:SetNextSecondaryFire( CurTime() + 1 )
+    
+    if self.Weapon:GetNextSecondaryFire() < CurTime() + 1 then	
+        self.Weapon:SetNextSecondaryFire( CurTime() + 1 )
+    end
 
     -- Start lag compensate for traces.
     self.Owner:LagCompensation(true)


### PR DESCRIPTION
This commit patches a critical exploit clients can use dodge the re-fire rate on swarm spit. When doing a primary attack, the code sets the refire delay to one second regardless of the self.refire rate assigned to the swarm spit. Thus allowing the client to dodge the cooldown and spit faster.

The patch checks if there's less one second left on the cooldown before assigning the one second delay. If there's more than one second left, the remaining self.refire delay on the swarm spit will be retained; instead, of instantly getting dropped to one second regardless.