### PR TITLE
Add fail-proof redudancy

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/gamemode/server/player/sv_player_damage.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/gamemode/server/player/sv_player_damage.lua
@@ -106,21 +106,6 @@ function GM:PlayerTakeDamage(ent, infl, att, amount, dmginfo)
    ent.DMG = 0 -- clear
    GAMEMODE:ScalePlayerDamage(ent, ent:LastHitGroup() or HITGROUP_GENERIC, dmginfo, true)
    
-
-
-   -- general actions for pvp damage
-   
-   if ent != att and ValidEntity(att) and att:IsPlayer() and GetRoundState() == ROUND_ACTIVE and math.floor(dmginfo:GetDamage()) > 0 then
-      local txt = ""
-      if infl:GetClass() == "env_explosion" then
-         infl = "Grenade"
-         txt = infl..": "..tostring(math.Round(ent.DMG))
-      else
-         txt = (infl.PrintName or tostring(infl))..": "..tostring(math.Round(ent.DMG))
-      end
-      LogDMG(att,ent,txt)
-   end
-
    local gender = ent.Gender
    local alienform = ent:GetNWBool("alienform",false)
    local swarm = ent:IsSwarm()
@@ -144,6 +129,18 @@ function GM:PlayerTakeDamage(ent, infl, att, amount, dmginfo)
       util.StartBleeding(ent, dmginfo:GetDamage(), 10)
    end
 
+   -- general actions for pvp damage
+   
+   if ent != att and ValidEntity(att) and att:IsPlayer() and GetRoundState() == ROUND_ACTIVE and math.floor(dmginfo:GetDamage()) > 0 then
+      local txt = ""
+      if infl:GetClass() == "env_explosion" then
+         infl = "Grenade"
+         txt = infl..": "..tostring(math.Round(ent.DMG))
+      else
+         txt = (infl.PrintName or tostring(infl))..": "..tostring(math.Round(ent.DMG))
+      end
+      LogDMG(att,ent,txt)
+   end
 end
 
 


### PR DESCRIPTION
As it stands currently, if for some reason the rdm log doesn't work properly, it can break the entire gamemode. This is because the execution chain when a lua error happens gets terminated before the util.StartBleeding() function can be called.

By moving the LogDMG() function to the bottom of GM:PlayerTakeDamage() function, the gamemode will still function properly if for some reason the rdm logging ever experiences a lua error. It's an extremely bad coding practice to have separate elements be able to break each other like this.