### PR TITLE
Patch Teslar Reload Exploit

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_teslar/shared.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_teslar/shared.lua
@@ -176,6 +176,10 @@ function SWEP:Reload()
         self:SetIronsights(false)
         -- Set the ironsight to false
         self.Weapon:SetNetworkedBool("Reloading", true)
+        
+        --improper fix to the teslar reload exploit that works
+        --simply forces you wait to 2.5s before firing the weapon
+        self.Weapon:SetNextPrimaryFire(CurTime() + 2.5)
     end
     local waitdammit = (self.Owner:GetViewModel():SequenceDuration())
     timer.Simple(waitdammit + .1, 


### PR DESCRIPTION
This pull request fixes the teslar reload exploit as mentioned in issue #5. It forces you wait 2.5 seconds before firing the weapon after triggering a reload. This isn't the best way to resolve this issue; however, it isn't noticeable and the weapon is in a better state than previously.