### PR TITLE
Patch Shotgun Firerate Exploit

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_base_pump/shared.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_base_pump/shared.lua
@@ -81,7 +81,10 @@ function SWEP:Deploy()
 
 	self.Weapon:SendWeaponAnim(ACT_VM_DRAW)
 
-	self.Weapon:SetNextPrimaryFire(CurTime() + .25)
+	if self.Weapon:GetNextPrimaryFire() < CurTime() + .25 then
+		self.Weapon:SetNextPrimaryFire(CurTime() + .25)
+	end
+	
 	self.Weapon:SetNextSecondaryFire(CurTime() + .25)
 	self.ActionDelay = (CurTime() + .25)
 


### PR DESCRIPTION
This pull request patches an exploit with the shotgun which allows the user to decrease the firerate. When firing and quickly changing weapons, the next fire delay is set to 0.25s.

This patch actually gets the next fire delay; and, only sets 0.25s, if there's less time remaining.