### PR TITLE
Nerf Blaster Damage & Cleanup

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_blasterbolt/init.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/entities/sent_blasterbolt/init.lua
@@ -16,9 +16,7 @@ function ENT:Initialize()
 	-- Sprite Trail Effect
 	if SERVER then
 		util.SpriteTrail(self.Entity, 0, Color(255, 155, 45, 255), false, 25, 0.5, 0.3, 45, "trails/plasma.vmt")
-	end
 
-	if SERVER then
 		local phys = self:GetPhysicsObject()
 		if phys:IsValid() then
 			phys:Wake()
@@ -29,13 +27,7 @@ function ENT:Initialize()
 end
 
 
-function ENT:Think()
-
-end
-
-
 function ENT:Explode()
-
 	-- SFX
 	ParticleEffect( "energy_blast", self:GetPos(), Angle(0, 0, 0), nil )
 	self.Entity:EmitSound( "weapons/blaster/blaster_hit.wav", 100, math.random(95,125) );
@@ -46,7 +38,7 @@ function ENT:Explode()
 			local dmginfo = DamageInfo()
 			dmginfo:SetAttacker( self:GetOwner() )
 			dmginfo:SetInflictor( self )
-			dmginfo:SetDamage( 25 )
+			dmginfo:SetDamage( 15 )
 			v:TakeDamageInfo( dmginfo )
 		end
 	end
@@ -61,18 +53,10 @@ function ENT:Explode()
 			v:TakeDamageInfo( dmginfo )
 		end
 	end
-
 end
 
 
 function ENT:PhysicsCollide( data, phys )
-
 	self:Explode()
 	self:Remove()
-
-end
-
-
-function ENT:OnRemove()
-
 end


### PR DESCRIPTION
Forty damage to broods on a critical shot is insanely overpowered. Reducing this to thirty has a hugely positive effect on game balance. There's also some redundancy in the file which can be removed.