### PR TITLE
Add Swarn Spawn Protection

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/gamemode/server/player/sv_player.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/gamemode/server/player/sv_player.lua
@@ -39,8 +39,8 @@ function GM:PlayerInitialSpawn(ply)
    ply.DamageFactor = 1
    ply:InitSanity()
    ply:SetNWInt("Mute_Status",0)
-
-
+   
+   ply:SpawnProtected = false
 
    --ply:SetForceRPName( 0 ) -- 0 = no, 1 = yes
    --ply:SetForceGender( 0 ) -- 0 = don't force, 1 = male, 2 = female


### PR DESCRIPTION
This pull request fixes humans camping the swarm spawn as mentioned in issue #11. It will give swarm aliens a set amount of time where they are protected from all damage after spawning. More commits to follow inside this pull request. It's best to double check the code one commit at a time.