### PR TITLE
Improve Base Weapon Class Performance

### DIFF
--- a/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_base/shared.lua
+++ b/MorbusGamemode/gamemodes/morbusgame/entities/weapons/weapon_mor_base/shared.lua
@@ -183,14 +183,8 @@ end
 Think
 ---------------------------------------------------------*/
 function SWEP:Think()
-	if (self.Weapon:GetNetworkedBool("Reloading")) then
-		self.Weapon:SetNWBool( "IsLaserOn", false )
-	else
-		self.Weapon:SetNWBool( "IsLaserOn", true )
-	end
-
+	self.Weapon:SetNWBool( "IsLaserOn", !self.Weapon:GetNetworkedBool("Reloading"))
 	self:IronSight()
-
 end
 
 


### PR DESCRIPTION
- Eliminate an un-needed if statement within think code by just setting the `"IsLaserOn"` boolean to the opposite value of `self.Weapon:GetNetworkedBool("Reloading")` directly as a function argument. (this actually works!)